### PR TITLE
Replace find by find_by_id in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ client = ::Pipedrive::Person.new('api_token')
 You can get person's JSON data:
 
 ```ruby
-person = client.find(12345)
+person = client.find_by_id(12345)
 person.success? # check what request was successful
 person.data # JSON data of person entity
 ```


### PR DESCRIPTION
`Find` doesn't work, it took me a few minutes to figure out that I should use `find_by_id` instead, lets save those precious minutes for the next guy