### PR TITLE
WIP: Support for file upload

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,9 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in pipedrive.gemspec
 gemspec
 
+# TODO: remove after release of new faraday middleware
+gem 'faraday_middleware', git: 'https://github.com/lostisland/faraday_middleware.git', branch: 'e169ab28a3f1fc6cc3160f86873903c7e5e8b882'
+
 group :test do
   gem 'simplecov', :require => false
   gem 'coveralls', :require => false

--- a/lib/pipedrive.rb
+++ b/lib/pipedrive.rb
@@ -48,6 +48,7 @@ require 'pipedrive/operations/create'
 require 'pipedrive/operations/read'
 require 'pipedrive/operations/update'
 require 'pipedrive/operations/delete'
+require 'pipedrive/operations/upload'
 
 # Persons
 require 'pipedrive/person_field'

--- a/lib/pipedrive/file.rb
+++ b/lib/pipedrive/file.rb
@@ -4,5 +4,6 @@ module Pipedrive
     include ::Pipedrive::Operations::Read
     include ::Pipedrive::Operations::Update
     include ::Pipedrive::Operations::Delete
+    include ::Pipedrive::Operations::Upload
   end
 end

--- a/lib/pipedrive/operations/upload.rb
+++ b/lib/pipedrive/operations/upload.rb
@@ -6,11 +6,12 @@ module Pipedrive
       extend ActiveSupport::Concern
 
       def upload(file, mime_type, params = {})
+        filename = ::File.basename(file)
         open(file) do |f|
           params = params.each_with_object({}) do |(key, val), h|
             h[key] = Faraday::ParamPart.new(val, nil, key)
           end
-          params[:file] = Faraday::UploadIO.new(f, mime_type)
+          params[:file] = Faraday::UploadIO.new(f, mime_type, filename)
 
           url = build_url([])
           response = self.class.file_upload_connection.post(url, params)

--- a/lib/pipedrive/operations/upload.rb
+++ b/lib/pipedrive/operations/upload.rb
@@ -1,0 +1,36 @@
+require 'open-uri'
+
+module Pipedrive
+  module Operations
+    module Upload
+      extend ActiveSupport::Concern
+
+      def upload(file, mime_type, params = {})
+        open(file) do |f|
+          params = params.each_with_object({}) do |(key, val), h|
+            h[key] = Faraday::ParamPart.new(val, nil, key)
+          end
+          params[:file] = Faraday::UploadIO.new(f, mime_type)
+
+          url = build_url([])
+          response = self.class.file_upload_connection.post(url, params)
+          process_response(response)
+        end
+      end
+
+      class_methods do
+        def file_upload_connection
+          @file_upload_connection ||= Faraday.new(self.faraday_options) do |conn|
+            conn.request :multipart
+            conn.request :url_encoded
+            conn.response :mashify
+            conn.response :json, content_type: /\bjson$/
+            conn.use FaradayMiddleware::ParseJson
+            conn.response :logger, ::Pipedrive.logger if ::Pipedrive.debug
+            conn.adapter Faraday.default_adapter
+          end
+        end
+      end
+    end
+  end
+end

--- a/pipedrive.gemspec
+++ b/pipedrive.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency('activesupport', '>= 4.0.0')
-  gem.add_dependency('faraday')
-  gem.add_dependency('faraday_middleware')
+  gem.add_dependency('faraday', '>= 1.0')
+  gem.add_dependency('faraday_middleware', '>= 1.0')
   gem.add_dependency('hashie', '>= 3.0')
   gem.add_development_dependency('bundler')
   gem.add_development_dependency('rake', '< 12')

--- a/spec/lib/pipedrive/operations/upload_spec.rb
+++ b/spec/lib/pipedrive/operations/upload_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe ::Pipedrive::Operations::Upload do
+  subject do
+    Class.new(::Pipedrive::Base) do
+      include ::Pipedrive::Operations::Upload
+
+      def entity_name
+        'bases'
+      end
+    end.new('token')
+  end
+
+  context '#upload' do
+    it 'should make a multipart api call' do
+      stub_request(:post, 'https://api.pipedrive.com/v1/bases?api_token=token').to_return(:status => 200, :body => {}.to_json, :headers => {})
+      expect_any_instance_of(::Faraday::Connection).to(receive(:post).with('/v1/bases?api_token=token', hash_including(
+        file: an_instance_of(Faraday::UploadIO),
+        deal_id: an_instance_of(Faraday::ParamPart)
+      ))).and_call_original
+
+      subject.upload('./Gemfile', 'text/plain', deal_id: 123)
+    end
+  end
+end


### PR DESCRIPTION
At the moment, the File client follows the same implementation as all other endpoints. If you want to upload a file though, the API expects a multipart request containing the file contents + parameters.

This PR tries to solve this by introducing a new convern `Upload`.
Unfortunately this is a very recent feature of Faraday (>= v1.0), so I had to introduce that version constraint. 
Furthermore, the Faraday guys haven't released a new, compatible version of `faraday_middleware` yet (see https://github.com/lostisland/faraday_middleware/issues/200), so this gem is temporarily bound to the corresponding Github commit (https://github.com/lostisland/faraday_middleware/commit/e169ab28a3f1fc6cc3160f86873903c7e5e8b882).

Because of this I open this PR as draft and to be discussed.
Cheers 