### PR TITLE
[fix] Fix undefined method extract_options! issue.

### DIFF
--- a/lib/pipedrive.rb
+++ b/lib/pipedrive.rb
@@ -2,6 +2,7 @@
 
 require 'logger'
 require 'active_support/core_ext/hash'
+require 'active_support/core_ext/array'
 require 'active_support/concern'
 require 'active_support/inflector'
 


### PR DESCRIPTION
There were failing test statements (specifically when doing read operations) because of the missing active support array extension.
Added to the main file