### PR TITLE
Add NoteField and OrganizationRelationship APIs

### DIFF
--- a/lib/pipedrive.rb
+++ b/lib/pipedrive.rb
@@ -92,6 +92,7 @@ require 'pipedrive/file'
 
 # Notes
 require 'pipedrive/note'
+require 'pipedrive/note_field'
 
 # Users
 require 'pipedrive/user'

--- a/lib/pipedrive.rb
+++ b/lib/pipedrive.rb
@@ -57,6 +57,7 @@ require 'pipedrive/person'
 
 # Organizations
 require 'pipedrive/organization_field'
+require 'pipedrive/organization_relationship'
 require 'pipedrive/organization'
 
 # Filters

--- a/lib/pipedrive/note_field.rb
+++ b/lib/pipedrive/note_field.rb
@@ -1,0 +1,9 @@
+module Pipedrive
+  class NoteField < Base
+    include ::Pipedrive::Operations::Read
+
+    def entity_name
+      'noteFields'
+    end
+  end
+end

--- a/lib/pipedrive/organization_relationship.rb
+++ b/lib/pipedrive/organization_relationship.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Pipedrive
+  class OrganizationRelationship < Base
+    include ::Pipedrive::Operations::Read
+    include ::Pipedrive::Operations::Create
+    include ::Pipedrive::Operations::Update
+    include ::Pipedrive::Operations::Delete
+
+    def entity_name
+      'organizationRelationships'
+    end
+  end
+end

--- a/spec/lib/pipedrive/note_field_spec.rb
+++ b/spec/lib/pipedrive/note_field_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ::Pipedrive::NoteField do
+  subject { described_class.new('token') }
+
+  describe '#entity_name' do
+    subject { super().entity_name }
+
+    it { is_expected.to eq('noteFields') }
+  end
+end

--- a/spec/lib/pipedrive/organization_relationship_spec.rb
+++ b/spec/lib/pipedrive/organization_relationship_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ::Pipedrive::OrganizationRelationship do
+  subject { described_class.new('token') }
+
+  describe '#entity_name' do
+    subject { super().entity_name }
+
+    it { is_expected.to eq('organizationRelationships') }
+  end
+end


### PR DESCRIPTION
This adds support for the `noteFields` and `organizationRelationship` APIs:

- https://developers.pipedrive.com/docs/api/v1/NoteFields
- https://developers.pipedrive.com/docs/api/v1/OrganizationRelationships

`NoteFields` doesn't support create, update or delete. In a weird quirk, it also doesn't single-object GETs, so since `find_by_id` is grouped with `all` in `Pipedrive::Operations::Read`, currently `Pipedrive::NoteField.new.find_by_id(id)` exists and will try to hit the API, but will come back with
```
{"status"=>false, "error"=>"Unknown method .", "success"=>false, "not_authorized"=>false, "failed"=>false}
```

`OrganizationRelationships` should has a similar quirk for `delete_all` (not supported), but the other operations should be fine.

Let us know if you have a preferred method for dealing with this!

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203130393642269